### PR TITLE
Update model.py

### DIFF
--- a/model.py
+++ b/model.py
@@ -7,16 +7,14 @@ class Net(nn.Module):
         super(Net, self).__init__()
 
         self.conv1 = nn.Conv2d(1, 64, (5, 5), (1, 1), (2, 2))
-        self.conv2 = nn.Conv2d(64, 64, (3, 3), (1, 1), (1, 1))
-        self.conv3 = nn.Conv2d(64, 32, (3, 3), (1, 1), (1, 1))
-        self.conv4 = nn.Conv2d(32, 1 * (upscale_factor ** 2), (3, 3), (1, 1), (1, 1))
+        self.conv2 = nn.Conv2d(64, 32, (3, 3), (1, 1), (1, 1))
+        self.conv3 = nn.Conv2d(32, 1 * (upscale_factor ** 2), (3, 3), (1, 1), (1, 1))
         self.pixel_shuffle = nn.PixelShuffle(upscale_factor)
 
     def forward(self, x):
         x = F.tanh(self.conv1(x))
         x = F.tanh(self.conv2(x))
-        x = F.tanh(self.conv3(x))
-        x = F.sigmoid(self.pixel_shuffle(self.conv4(x)))
+        x = F.sigmoid(self.pixel_shuffle(self.conv3(x)))
         return x
 
 


### PR DESCRIPTION
modified network as paper's implementations

In the original paper, they mentioned.

"For the ESPCN, we set l = 3, (f1, n1) = (5, 64), (f2, n2) = (3, 32) and f3 = 3 in our evaluations. The choice of the parameter is inspired by SRCNN’s 3 layer 9-5-5 model and the equations in Sec. 2.2."

So, I removed one layer and adjusted the number of filters.